### PR TITLE
add support for block versions >25 and <28

### DIFF
--- a/src/main/java/io/rudin/minetest/tileserver/util/MapBlockParser.java
+++ b/src/main/java/io/rudin/minetest/tileserver/util/MapBlockParser.java
@@ -52,7 +52,7 @@ public class MapBlockParser {
 		block.version = data[0];
 
 
-		if (block.version != 28) {
+		if (block.version < 25 || block.version > 28) {
 			logger.error("block version not supported: {}", block.version);
 			throw new IllegalArgumentException("block version not supported: " + block.version);
 		}
@@ -68,7 +68,7 @@ public class MapBlockParser {
 		//data[4] = content_width (2)
 
 		//data[5] = params_width (2)
-		int dataOffset = 6;
+		int dataOffset = block.version >= 27 ? 6 : 4;
 
 		Inflater inflater = new Inflater();
 		inflater.setInput(data, dataOffset, data.length - dataOffset);


### PR DESCRIPTION
This PR relates to #7 ([this comment](https://github.com/thomasrudin-mt/minetest-tile-server/issues/7#issuecomment-445548529))

According to [documentation](https://dev.minetest.net/Basic_data_structures):
```
// This describes version 22 and higher
 
u8 flags; // is_underground:0x1, m_day_night_differs:0x2, !m_generated:0x8
u16 m_lighting_complete; // since version 27
u8 content_width; // can only be 1 or 2
u8 params_width; // always set to 2
bulk_data; // compressed
...
...
```
it was added 2 bytes since version 27
```
u16 m_lighting_complete; // since version 27
```

So, we need to change `dataOffset` for 2 (see PR code)

**P.S.:** _We tested this with block versions `25` on Minetest v. `0.4.16`_